### PR TITLE
Improve unit tests

### DIFF
--- a/.kube/config
+++ b/.kube/config
@@ -1,0 +1,14 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: http://127.0.0.1:8080
+  name: test-fake-server
+contexts:
+- context:
+    cluster: test-fake-server
+    user: ""
+  name: test-fake-server
+current-context: test-fake-server
+kind: Config
+preferences: {}
+users: {}

--- a/pkg/clientset/clientset_test.go
+++ b/pkg/clientset/clientset_test.go
@@ -9,7 +9,8 @@ import (
 const nonExistentPath = "\\/hopefully/non/existent/path"
 
 func TestClientSet(t *testing.T) {
-	t.Skip("Skipping TestClientSet for now: depends on configured ~/.kube or running in cluster")
+	here, _ := os.Getwd()
+	os.Setenv("HOME", here+"/../..")
 	cs, err := NewClientSet("", "")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -15,12 +15,10 @@ func healthCheckReply(w http.ResponseWriter, r *http.Request) {
 }
 
 // HeartBeatService exposes an http healthcheck handler
-func HeartBeatService(c *config.KdnConfig) {
+func HeartBeatService(c *config.KdnConfig) error {
 	if c.HealthPort == 0 {
-		return
+		return nil
 	}
 	http.HandleFunc("/health", healthCheckReply)
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", c.HealthPort), nil); err != nil {
-		panic(fmt.Sprintf("Failed to start http healtcheck: %s", err))
-	}
+	return http.ListenAndServe(fmt.Sprintf(":%d", c.HealthPort), nil)
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/bpineau/kube-deployments-notifier/config"
 )
 
 func TestHealthCheckHandler(t *testing.T) {
@@ -22,5 +24,15 @@ func TestHealthCheckHandler(t *testing.T) {
 
 	if rr.Body.String() != "ok\n" {
 		t.Errorf("healthCheckReply didn't return 'ok\n'")
+	}
+
+	conf := new(config.KdnConfig)
+	if HeartBeatService(conf) != nil {
+		t.Errorf("HeartBeatService should ignore unconfigured healthcheck")
+	}
+
+	conf.HealthPort = -42
+	if HeartBeatService(conf) == nil {
+		t.Errorf("HeartBeatService should fail with a wrong port")
 	}
 }

--- a/pkg/notifiers/http/http_test.go
+++ b/pkg/notifiers/http/http_test.go
@@ -33,6 +33,12 @@ func TestHttpNotifier(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to notify a deletion")
 	}
+
+	conf.Endpoint = ""
+	err = notifier.Changed(conf, "foo")
+	if err != nil {
+		t.Errorf("HTTP notifier should ignore null endpoints")
+	}
 }
 
 func TestHttpNotifierNoEndpoint(t *testing.T) {
@@ -67,4 +73,12 @@ func TestHttpNotifierFailures(t *testing.T) {
 	if err == nil {
 		t.Errorf("Failed to notice request failure")
 	}
+
+	conf.Endpoint = ":"
+
+	err = notifier.Changed(conf, "baz")
+	if err == nil {
+		t.Errorf("Failed to notice a unparsable url")
+	}
+
 }

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"log"
 	"os"
 	"os/signal"
 	"sync"
@@ -32,7 +33,7 @@ func Run(config *config.KdnConfig) {
 		}(c)
 	}
 
-	go health.HeartBeatService(config)
+	go log.Fatal(health.HeartBeatService(config))
 
 	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, syscall.SIGTERM)


### PR DESCRIPTION
* Re-enable clienset tests (providing them a fake kubeconfig)
* We can cover all possible logger configs
* We can cover more of healthcheck code