### PR TITLE
Provide a public docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,3 +12,9 @@ release:
   # don't autopublish
   draft: true
 
+dockers:
+  -
+    image: bpineau/kube-deployments-notifier
+    goos: linux
+    goarch: amd64
+    latest: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.9.2 as builder
+WORKDIR /go/src/github.com/bpineau/kube-deployments-notifier
+COPY . .
+RUN go get -u github.com/Masterminds/glide
+RUN make deps
+RUN make build
+
+FROM alpine:3.7
+RUN apk --no-cache add ca-certificates
+COPY --from=builder /go/src/github.com/bpineau/kube-deployments-notifier/kube-deployments-notifier /usr/bin/
+ENTRYPOINT ["/usr/bin/kube-deployments-notifier"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 An example Kubernetes controller that list and watch deployments, and send
 them as json payload to a remote API endpoint.
 
+## Docker image
+
+A ready to use, public docker image is available at [Docker Hub](https://hub.docker.com/r/bpineau/kube-deployments-notifier/), published at each release.
+You can use it directly from your Kubernetes deployments, ie.
+
+```yaml
+image: bpineau/kube-deployments-notifier:v0.2.0
+args:
+  - -l 'vendor=mycompany,app!=mmp-database'
+  - -e http://myapiserver:804
+```
+
 ## Build
 
 Assuming you have go 1.9 and glide in the path, and GOPATH configured:


### PR DESCRIPTION
No need to build the image yourself, just pull bpineau/kube-deployments-notifier.
The image will be updated, at each release, by goreleaser. The "latest" tag will
follow the last release.