### PR TITLE
Don't fail on missing healthcheck port

### DIFF
--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -33,7 +33,7 @@ func Run(config *config.KdnConfig) {
 		}(c)
 	}
 
-	go log.Fatal(health.HeartBeatService(config))
+	go log.Println(health.HeartBeatService(config))
 
 	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, syscall.SIGTERM)


### PR DESCRIPTION
Running kube-deployments-notifier without providing a healthcheck
port is ok and shouldn't prevent the application from running.

While at it, give a more complet deployment manifest example (so
the healthcheck url is documented now).