### PR TITLE
Fix docker images build from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 builds:
   -
+    ldflags: -s -w -X github.com/bpineau/kube-deployments-notifier/cmd.version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -18,3 +19,4 @@ dockers:
     goos: linux
     goarch: amd64
     latest: true
+    dockerfile: Dockerfile.goreleaser

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,4 @@
+FROM alpine:3.7
+RUN apk --no-cache add ca-certificates
+COPY kube-deployments-notifier /usr/bin/
+ENTRYPOINT ["/usr/bin/kube-deployments-notifier"]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ spec:
     spec:
       containers:
         - name: kube-deployments-notifier
-          image: bpineau/kube-deployments-notifier:v0.2.0
+          image: bpineau/kube-deployments-notifier:0.2.0
           args:
             - --filter 'vendor=mycompany,app!=mmp-database'
             - --endpoint https://myapiserver


### PR DESCRIPTION
It seems that goreleaser don't launch docker build from the
project's root, but from the dist/$arch/ directory, which
contains the freshly built artifact.

So we can't use the generic Dockerfile for goreleaser.

The generic Dockefile remains useful for anyone who want to
build k-d-n with a ready to use toolchain.

Also, goreleaser strips the "v" prefix from version when
building docker images tags.