### PR TITLE
More unit tests, and automated coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ install:
 script:
   - make lint
   - make test
+  - make coverall
   - make install
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all: build
 tools:
 	which gometalinter || ( go get -u github.com/alecthomas/gometalinter && gometalinter --install )
 	which glide || go get -u github.com/Masterminds/glide
+	which goveralls || go get github.com/mattn/goveralls
 
 lint:
 	gometalinter --concurrency=1 --deadline=300s --vendor --disable-all \
@@ -44,7 +45,11 @@ clean:
 	rm -rf dist/
 	go clean -i
 
-test:
-	go test -race -cover -v github.com/bpineau/kube-deployments-notifier/pkg/...
+coverall:
+	goveralls -service=travis-ci -package github.com/bpineau/kube-deployments-notifier/pkg/...
 
-.PHONY: tools lint fmt install clean test all
+test:
+	go test -i github.com/bpineau/kube-deployments-notifier/...
+	go test -race -cover github.com/bpineau/kube-deployments-notifier/...
+
+.PHONY: tools lint fmt install clean coverall test all

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # kube-deployments-notifier
 
 [![Build Status](https://travis-ci.org/bpineau/kube-deployments-notifier.svg?branch=master)](https://travis-ci.org/bpineau/kube-deployments-notifier)
+[![Coverage Status](https://coveralls.io/repos/github/bpineau/kube-deployments-notifier/badge.svg?branch=master)](https://coveralls.io/github/bpineau/kube-deployments-notifier?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/bpineau/kube-deployments-notifier)](https://goreportcard.com/report/github.com/bpineau/kube-deployments-notifier)
 
 An example Kubernetes controller that list and watch deployments, and send

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/bpineau/kube-deployments-notifier/config"
 	klog "github.com/bpineau/kube-deployments-notifier/pkg/log"
+	"github.com/bpineau/kube-deployments-notifier/pkg/notifiers"
 	"github.com/bpineau/kube-deployments-notifier/pkg/run"
 )
 
@@ -36,22 +36,25 @@ var (
 	healthP   int
 	resync    int
 
+	// FakeCS uses the client-go testing clientset
+	FakeCS bool
+
 	versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%s version %s\n", appName, version)
+			RootCmd.Printf("%s version %s\n", appName, version)
 		},
 	}
 
-	// rootCmd represents the base command when called without any subcommands
-	rootCmd = &cobra.Command{
+	// RootCmd represents the base command when called without any subcommands
+	RootCmd = &cobra.Command{
 		Use:   appName,
 		Short: "Notify deployments",
 		Long:  "Notify deployments",
 
-		Run: func(cmd *cobra.Command, args []string) {
-			config := &config.KdnConfig{
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conf := &config.KdnConfig{
 				DryRun:     viper.GetBool("dry-run"),
 				Logger:     klog.New(viper.GetString("log.level"), viper.GetString("log.server"), viper.GetString("log.output")),
 				Endpoint:   viper.GetString("endpoint"),
@@ -61,69 +64,74 @@ var (
 				HealthPort: viper.GetInt("healthcheck-port"),
 				ResyncIntv: time.Duration(viper.GetInt("resync-interval")) * time.Second,
 			}
-			config.Init(viper.GetString("api-server"), viper.GetString("kube-config"))
-			run.Run(config)
+			if FakeCS {
+				conf.ClientSet = config.FakeClientSet()
+			}
+			err := conf.Init(viper.GetString("api-server"), viper.GetString("kube-config"))
+			if err != nil {
+				return fmt.Errorf("Failed to initialize the configuration: %+v", err)
+			}
+			run.Run(conf, notifiers.Init(notifiers.Backends))
+			return nil
 		},
 	}
 )
 
 // Execute adds all child commands to the root command and sets their flags.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		panic(err)
-	}
+func Execute() error {
+	return RootCmd.Execute()
 }
 
 func bindPFlag(key string, cmd string) {
-	if err := viper.BindPFlag(key, rootCmd.PersistentFlags().Lookup(cmd)); err != nil {
+	if err := viper.BindPFlag(key, RootCmd.PersistentFlags().Lookup(cmd)); err != nil {
 		log.Fatal("Failed to bind cli argument:", err)
 	}
 }
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.AddCommand(versionCmd)
+	RootCmd.AddCommand(versionCmd)
 
 	defaultCfg := "/etc/kdn/" + appName + ".yaml"
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", defaultCfg, "configuration file")
+	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", defaultCfg, "configuration file")
 
-	rootCmd.PersistentFlags().StringVarP(&apiServer, "api-server", "s", "", "kube api server url")
+	RootCmd.PersistentFlags().StringVarP(&apiServer, "api-server", "s", "", "kube api server url")
 	bindPFlag("api-server", "api-server")
 
-	rootCmd.PersistentFlags().StringVarP(&kubeConf, "kube-config", "k", "", "kube config path")
+	RootCmd.PersistentFlags().StringVarP(&kubeConf, "kube-config", "k", "", "kube config path")
 	bindPFlag("kube-config", "kube-config")
 	if err := viper.BindEnv("kube-config", "KUBECONFIG"); err != nil {
 		log.Fatal("Failed to bind cli argument:", err)
 	}
 
-	rootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "dry-run mode")
+	RootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "dry-run mode")
 	bindPFlag("dry-run", "dry-run")
 
-	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "v", "debug", "log level")
+	RootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "v", "debug", "log level")
 	bindPFlag("log.level", "log-level")
 
-	rootCmd.PersistentFlags().StringVarP(&logOutput, "log-output", "o", "stderr", "log output")
+	RootCmd.PersistentFlags().StringVarP(&logOutput, "log-output", "o", "stderr", "log output")
 	bindPFlag("log.output", "log-output")
 
-	rootCmd.PersistentFlags().StringVarP(&logServer, "log-server", "r", "", "log server (if using syslog)")
+	RootCmd.PersistentFlags().StringVarP(&logServer, "log-server", "r", "", "log server (if using syslog)")
 	bindPFlag("log.server", "log-server")
 
-	rootCmd.PersistentFlags().StringVarP(&endpoint, "endpoint", "e", "", "API endpoint")
+	RootCmd.PersistentFlags().StringVarP(&endpoint, "endpoint", "e", "", "API endpoint")
 	bindPFlag("endpoint", "endpoint")
 
-	rootCmd.PersistentFlags().StringVarP(&tokenHdr, "token-header", "t", "", "token header name")
+	RootCmd.PersistentFlags().StringVarP(&tokenHdr, "token-header", "t", "", "token header name")
 	bindPFlag("token-header", "token-header")
 
-	rootCmd.PersistentFlags().StringVarP(&tokenVal, "token-value", "a", "", "token header value")
+	RootCmd.PersistentFlags().StringVarP(&tokenVal, "token-value", "a", "", "token header value")
 	bindPFlag("token-value", "token-value")
 
-	rootCmd.PersistentFlags().StringVarP(&filter, "filter", "l", "", "Label filter")
+	RootCmd.PersistentFlags().StringVarP(&filter, "filter", "l", "", "Label filter")
 	bindPFlag("filter", "filter")
 
-	rootCmd.PersistentFlags().IntVarP(&healthP, "healthcheck-port", "p", 0, "port for answering healthchecks")
+	RootCmd.PersistentFlags().IntVarP(&healthP, "healthcheck-port", "p", 0, "port for answering healthchecks")
 	bindPFlag("healthcheck-port", "healthcheck-port")
 
-	rootCmd.PersistentFlags().IntVarP(&resync, "resync-interval", "i", 900, "resync interval in seconds (0 to disable)")
+	RootCmd.PersistentFlags().IntVarP(&resync, "resync-interval", "i", 900, "resync interval in seconds (0 to disable)")
 	bindPFlag("resync-interval", "resync-interval")
 }
 
@@ -150,6 +158,6 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err == nil {
-		logrus.Info("Using config file: ", viper.ConfigFileUsed())
+		RootCmd.Printf("Using config file: %s", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/execute_test.go
+++ b/cmd/execute_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"bytes"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// most of cli binding code is executed through the magical init() mecanism
+func TestRootCmd(t *testing.T) {
+	FakeCS = true
+	RootCmd.SetOutput(new(bytes.Buffer))
+	RootCmd.SetArgs([]string{
+		"--config",
+		"/dev/null",
+		"--dry-run",
+		"--api-server",
+		"http://127.0.0.1",
+		"--log-level",
+		"warning",
+		"--log-output",
+		"test",
+		"--endpoint",
+		"http://example.com",
+		"--token-header",
+		"Foo",
+		"--token-value",
+		"Bar",
+		"--healthcheck-port",
+		"0",
+		"--filter",
+		"foo=bar,spam=egg",
+		"--resync-interval",
+		"1",
+	})
+
+	ch := make(chan error, 1)
+
+	go func() {
+		ch <- Execute()
+	}()
+
+	select {
+	case err := <-ch:
+		if err != nil {
+			t.Errorf("Failed to execute the main command: %+v", err)
+		}
+	case <-time.After(time.Second):
+		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	case <-time.After(10 * time.Second):
+		t.Error("Timeout waiting for the execute command to exit after SIGTERM")
+	}
+
+	FakeCS = false
+
+	RootCmd.SetArgs([]string{
+		"--dry-run",
+		"--api-server",
+		"http://127.0.0.1",
+		"--config",
+		"\\/non/existent/path",
+	})
+	if err := Execute(); err == nil {
+		t.Error("Execute() should fail with unreachable config file path")
+	}
+
+	RootCmd.SetArgs([]string{
+		"--dry-run",
+		"--api-server",
+		"http://127.0.0.1",
+		"--config",
+	})
+	if err := Execute(); err == nil {
+		t.Error("Execute() should fail with missing flags arguments")
+	}
+}
+
+func TestVersion(t *testing.T) {
+	RootCmd.SetOutput(new(bytes.Buffer))
+	RootCmd.SetArgs([]string{"version"})
+	if err := RootCmd.Execute(); err != nil {
+		t.Errorf("version subcommand shouldn't fail: %+v", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -24,18 +24,22 @@ type KdnConfig struct {
 }
 
 // Init initialize the configuration (creating the ClientSet for the cluster)
-func (c *KdnConfig) Init(apiserver string, kubeconfig string) {
+func (c *KdnConfig) Init(apiserver string, kubeconfig string) error {
 	var err error
 
-	c.ClientSet, err = clientset.NewClientSet(apiserver, kubeconfig)
-	if err != nil {
-		panic(fmt.Errorf("Failed init Kubernetes clientset: %+v", err))
+	if c.ClientSet == nil {
+		c.ClientSet, err = clientset.NewClientSet(apiserver, kubeconfig)
+		if err != nil {
+			return fmt.Errorf("Failed init Kubernetes clientset: %+v", err)
+		}
 	}
 
+	// better fail early, if we can't talk to the cluster's api
 	_, err = c.ClientSet.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
-		panic(fmt.Errorf("Failed to query Kubernetes api-server: %+v", err))
+		return fmt.Errorf("Failed to query Kubernetes api-server: %+v", err)
 	}
 
 	c.Logger.Info("Kubernetes clientset initialized")
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+const nonExistentPath = "\\/hopefully/non/existent/path"
+
+func TestConfig(t *testing.T) {
+	conf := FakeConfig()
+	if conf == nil {
+		t.Error("Failed to initialize a fake config object")
+	}
+
+	// test with the fake clientset (should panic on error)
+	err := conf.Init("", "")
+	if err != nil {
+		t.Errorf("Failed to initialize conf: %+v", err)
+	}
+	if fmt.Sprintf("%T", conf.ClientSet) != "*fake.Clientset" {
+		t.Errorf("conf.Init() shouldn't overwrite an existing ClientSet")
+	}
+
+	// test with a real clientset
+	conf.ClientSet = nil
+	here, _ := os.Getwd()
+	os.Setenv("HOME", here+"/../..")
+	_ = conf.Init("http://127.0.0.1", "/dev/null")
+	if fmt.Sprintf("%T", conf.ClientSet) != "*kubernetes.Clientset" {
+		t.Errorf("Should have a real *kubernetes.Clientset")
+	}
+
+	// ensure we raise an error if the provided config file is unreachable
+	conf.ClientSet = nil
+	err = conf.Init("http://127.0.0.1", nonExistentPath)
+	if err == nil {
+		t.Fatal("conf.Init() should fail on non existent kubeconfig path")
+	}
+}

--- a/config/fakeconfig.go
+++ b/config/fakeconfig.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/bpineau/kube-deployments-notifier/pkg/log"
+)
+
+var (
+	// FakeResyncInterval is the interval between resyncs during tests
+	FakeResyncInterval = time.Duration(time.Second)
+
+	// Labels use to filter objets in the tests runs
+	Labels = map[string]string{"foo": "bar", "spam": "egg"}
+)
+
+// FakeConfig returns a config objet using a fake clientset (for tests)
+func FakeConfig(objects ...runtime.Object) *KdnConfig {
+	c := &KdnConfig{
+		DryRun:     true,
+		Logger:     log.New("", "", "test"),
+		ClientSet:  fake.NewSimpleClientset(objects...),
+		Endpoint:   "http://example.com",
+		TokenHdr:   "",
+		TokenVal:   "",
+		Filter:     "foo=bar,spam=egg",
+		ResyncIntv: FakeResyncInterval,
+	}
+
+	return c
+}
+
+// FakeClientSet provides a fake.NewSimpleClientset, useful for testing
+func FakeClientSet() *fake.Clientset {
+	return fake.NewSimpleClientset()
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,23 @@
 package main
 
-import "github.com/bpineau/kube-deployments-notifier/cmd"
+import (
+	"fmt"
+	"os"
+
+	"github.com/bpineau/kube-deployments-notifier/cmd"
+)
+
+//var privateExitHandler func(code int) = os.Exit
+var privateExitHandler = os.Exit
+
+// ExitWrapper allow unit tests on main() exit values
+func ExitWrapper(exit int) {
+	privateExitHandler(exit)
+}
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		fmt.Printf("%+v", err)
+		ExitWrapper(1)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bpineau/kube-deployments-notifier/cmd"
+)
+
+func TestMain(t *testing.T) {
+	var ok = true
+
+	privateExitHandler = func(c int) {
+		ok = false
+	}
+
+	cmd.FakeCS = true
+	cmd.RootCmd.SetOutput(new(bytes.Buffer))
+
+	// test with normal exit
+	cmd.RootCmd.SetArgs([]string{"--help"})
+	main()
+
+	if !ok {
+		t.Errorf("main() failed")
+	}
+
+	// test with failure
+	cmd.RootCmd.SetArgs([]string{"--unexpected-arg"})
+	main()
+
+	if ok {
+		t.Errorf("main() should fail with unexpected arguments")
+	}
+}
+
+func TestExitWrapper(t *testing.T) {
+	var ok = false
+
+	privateExitHandler = func(c int) {
+		ok = true
+	}
+
+	ExitWrapper(1)
+
+	if !ok {
+		t.Errorf("Error in ExitWrapper()")
+	}
+}

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -1,0 +1,154 @@
+package controllers
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/bpineau/kube-deployments-notifier/config"
+	"github.com/bpineau/kube-deployments-notifier/pkg/notifiers"
+	"github.com/bpineau/kube-deployments-notifier/pkg/notifiers/count"
+)
+
+var (
+	obj1 = &v1.Pod{ObjectMeta: meta_v1.ObjectMeta{
+		Name:      "test1",
+		Labels:    config.Labels,
+		Namespace: v1.NamespaceDefault},
+	}
+	obj2 = &v1.Pod{ObjectMeta: meta_v1.ObjectMeta{
+		Name:      "test2",
+		Labels:    config.Labels,
+		Namespace: v1.NamespaceDefault},
+	}
+	obj3 = &v1.Pod{ObjectMeta: meta_v1.ObjectMeta{
+		Name:      "test3",
+		Labels:    map[string]string{"wrong": "label"},
+		Namespace: v1.NamespaceDefault},
+	}
+	obj4 = &v1.Pod{ObjectMeta: meta_v1.ObjectMeta{
+		Name:      "test4",
+		Labels:    config.Labels,
+		Namespace: v1.NamespaceDefault},
+	}
+)
+
+type testController struct {
+	CommonController
+}
+
+// Init initialize pod controller
+func (c *testController) Init(conf *config.KdnConfig, n notifiers.Notifier) Controller {
+	c.CommonController = CommonController{
+		Conf:      conf,
+		Name:      "pod",
+		Notifiers: n,
+	}
+
+	client := c.Conf.ClientSet
+	c.ObjType = &v1.Pod{}
+	selector := meta_v1.ListOptions{LabelSelector: conf.Filter}
+
+	ls := new(cache.ListWatch)
+	ls.ListFunc = func(options meta_v1.ListOptions) (runtime.Object, error) {
+		return client.CoreV1().Pods(meta_v1.NamespaceAll).List(selector)
+	}
+	ls.WatchFunc = func(options meta_v1.ListOptions) (watch.Interface, error) {
+		return client.CoreV1().Pods(meta_v1.NamespaceAll).Watch(selector)
+	}
+	c.ListWatch = ls
+
+	return c
+}
+
+type failingNotifier struct {
+	sync.Mutex
+	changeCalls int
+	deleteCalls int
+}
+
+// Changed is a failing and counting change notifier
+func (l *failingNotifier) Changed(c *config.KdnConfig, msg string) error {
+	l.Lock()
+	l.changeCalls++
+	l.Unlock()
+	return fmt.Errorf("Normal and expected error on change event")
+}
+
+// Deleted is a failing and counting delete notifier
+func (l *failingNotifier) Deleted(c *config.KdnConfig, msg string) error {
+	l.Lock()
+	l.deleteCalls++
+	l.Unlock()
+	return fmt.Errorf("Normal and expected error on delete event")
+}
+
+func (l *failingNotifier) countChange() int {
+	l.Lock()
+	defer l.Unlock()
+	return l.changeCalls
+}
+
+func (l *failingNotifier) countDelete() int {
+	l.Lock()
+	defer l.Unlock()
+	return l.deleteCalls
+}
+
+func TestController(t *testing.T) {
+	c := config.FakeConfig(obj1, obj2, obj3)
+	n := new(count.Notifier)
+	cont := &testController{}
+	cont.Init(c, n)
+	if cont == nil {
+		t.Errorf("Failed to initialize a test pod controller")
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	defer wg.Wait()
+	go cont.Start(&wg)
+	defer func(cont Controller) {
+		go cont.Stop()
+	}(cont)
+
+	// test initial event list and filtering
+	time.Sleep(config.FakeResyncInterval + config.FakeResyncInterval/2)
+	if n.Count() != 4 { // 2 initial + 2 after resync
+		t.Errorf("Expected 4 notification, got %d", n.Count())
+	}
+
+	// test deletion
+	store := cont.Informer.GetStore()
+	store.Delete(obj2)
+	time.Sleep(config.FakeResyncInterval + config.FakeResyncInterval/2)
+
+	if n.Count() < 5 {
+		t.Errorf("Expected 5 notification, got %d", n.Count())
+	}
+
+	// test deletion notification path
+	cont.Queue.Add("fake/fake")
+
+	// test retries on notifiers failure
+	fnotif := new(failingNotifier)
+	cont.Notifiers = fnotif
+	store.Add(obj4)
+
+	time.Sleep(config.FakeResyncInterval + config.FakeResyncInterval/2)
+	if fnotif.countChange() < maxProcessRetry {
+		t.Errorf("Should retry %d times on failing notifiers, got %d retries",
+			maxProcessRetry,
+			fnotif.countChange())
+	}
+	if fnotif.countDelete() < maxProcessRetry {
+		t.Errorf("Notified should get a deletion event")
+	}
+}

--- a/pkg/controllers/deployment/deployment_test.go
+++ b/pkg/controllers/deployment/deployment_test.go
@@ -1,0 +1,44 @@
+package deployment
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/apps/v1beta1"
+
+	"github.com/bpineau/kube-deployments-notifier/config"
+	"github.com/bpineau/kube-deployments-notifier/pkg/notifiers/count"
+)
+
+var (
+	obj1 = &v1beta1.Deployment{ObjectMeta: meta_v1.ObjectMeta{
+		Name:      "test1",
+		Labels:    config.Labels,
+		Namespace: v1.NamespaceDefault},
+	}
+)
+
+func TestDeployment(t *testing.T) {
+	notif := new(count.Notifier)
+	cont := new(Controller)
+	cont.Init(config.FakeConfig(obj1), notif)
+	if cont == nil {
+		t.Errorf("Failed to create a deployment controller")
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	defer wg.Wait()
+	go cont.Start(&wg)
+	defer func(cont *Controller) {
+		go cont.Stop()
+	}(cont)
+
+	time.Sleep(config.FakeResyncInterval + config.FakeResyncInterval/2)
+	if notif.Count() != 2 { // 1 initial + 1 after resync
+		t.Errorf("Expected 2 notification, got %d", notif.Count())
+	}
+}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -47,7 +47,7 @@ func TestLog(t *testing.T) {
 		t.Error("The default output should be stderr")
 	}
 
-	logger = New("info", "192.0.2.0:514", "syslog")
+	logger = New("info", "127.0.0.1:514", "syslog")
 	if fmt.Sprintf("%T", logger) != "*logrus.Logger" {
 		t.Error("Failed to instantiate a syslog logger")
 	}

--- a/pkg/run/run_test.go
+++ b/pkg/run/run_test.go
@@ -1,0 +1,49 @@
+package run
+
+import (
+	"syscall"
+	"testing"
+	"time"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/apps/v1beta1"
+
+	"github.com/bpineau/kube-deployments-notifier/config"
+	"github.com/bpineau/kube-deployments-notifier/pkg/notifiers/count"
+)
+
+var (
+	obj1 = &v1beta1.Deployment{ObjectMeta: meta_v1.ObjectMeta{
+		Name:      "test",
+		Labels:    config.Labels,
+		Namespace: v1.NamespaceDefault},
+	}
+)
+
+func TestRun(t *testing.T) {
+	conf := config.FakeConfig(obj1)
+	notif := new(count.Notifier)
+	go Run(conf, notif)
+
+	ch := make(chan int, 1)
+	defer close(ch)
+
+	go func() {
+		for notif.Count() == 0 {
+			time.Sleep(time.Second)
+		}
+		ch <- notif.Count()
+	}()
+
+	select {
+	case res := <-ch:
+		if res != 1 {
+			t.Errorf("Failed to convert an event to a notification")
+		}
+	case <-time.After(10 * time.Second):
+		t.Error("Timeout waiting for a event to pop up as a notification")
+	}
+
+	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+}


### PR DESCRIPTION
Now we have unit tests for all the code, and we'll follow
the code coverage deviations thanks to coverall.io.

While at it, fix a pair of (improbable) race conditions
uncovered by tests.