### PR TITLE
Log but don't fail if healthcheck service fail to start

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,6 +14,12 @@ func TestConfig(t *testing.T) {
 		t.Error("Failed to initialize a fake config object")
 	}
 
+	// test config's provided FakeClientSet we'll use throughout this file
+	cs := FakeClientSet()
+	if fmt.Sprintf("%T", cs) != "*fake.Clientset" {
+		t.Errorf("FakeClientSet() failed")
+	}
+
 	// test with the fake clientset (should panic on error)
 	err := conf.Init("", "")
 	if err != nil {

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"log"
 	"os"
 	"os/signal"
 	"sync"
@@ -35,7 +34,7 @@ func Run(config *config.KdnConfig, notif notifiers.Notifier) {
 
 	go func() {
 		if err := health.HeartBeatService(config); err != nil {
-			log.Fatal("Healtcheck service failed: ", err)
+			config.Logger.Warningf("Healtcheck service failed: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
As we already noted, this shouldn't be fatal.

Add enough unit tests to prevent healtcheck service to
become critical again.

While at it, unit test the config's FakeClientSet.