### PR TITLE
Add object kind to deletion notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,12 @@ spec:
     spec:
       containers:
         - name: kube-deployments-notifier
-          image: bpineau/kube-deployments-notifier:0.2.0
+          image: bpineau/kube-deployments-notifier:0.3.0
           args:
-            - --filter 'vendor=mycompany,app!=mmp-database'
-            - --endpoint https://myapiserver
-            - --healthcheck-port 8080
+            - --log-output=stdout
+            - --filter=vendor=mycompany,app!=mmp-database
+            - --endpoint=http://mycollector
+            - --healthcheck-port=8080
           resources:
             requests:
               cpu: 0.1

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -174,7 +174,8 @@ func (c *CommonController) processItem(key string) error {
 	jobj := fmt.Sprintf("%s", res)
 
 	if !exists {
-		return c.Notifiers.Deleted(c.Conf, fmt.Sprintf(`{"name":"%s"}`, key))
+		return c.Notifiers.Deleted(c.Conf,
+			fmt.Sprintf(`{"kind":"%s", "name":"%s"}`, c.Name, key))
 	}
 
 	return c.Notifiers.Changed(c.Conf, jobj)


### PR DESCRIPTION
Since a kubernetes object should be identified by his kind + name
(+ namespace, for some of them), providing the kind is requiered
if/when we extend the scope beyond deployments.

While at it, the sample deployment manifest was wrong, since kube
consider each args entry as a single arg.