### PR TITLE
README example: use the stable apiVersion string

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A ready to use, public docker image is available at [Docker Hub](https://hub.doc
 You can use it directly from your Kubernetes deployments, ie.
 
 ```yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-deployments-notifier


### PR DESCRIPTION
Since Kubernetes 1.9, the core workloads API (apps/) is GA.
apps/v1beta2 sill works indeed, but the new apps/v1 is future proof.