### PR TITLE
Switch from gometalinter to golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 all: build
 
 tools:
-	which gometalinter || ( go get -u github.com/alecthomas/gometalinter && gometalinter --install )
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.16.0
 	which glide || go get -u github.com/Masterminds/glide
 	which goveralls || go get github.com/mattn/goveralls
 
 lint:
-	gometalinter --concurrency=1 --deadline=300s --vendor --disable-all \
+	./bin/golangci-lint run --concurrency=1 --disable-all \
 		--enable=golint \
 		--enable=vet \
 		--enable=vetshadow \
@@ -17,7 +17,6 @@ lint:
 		--enable=deadcode \
 		--enable=ineffassign \
 		--enable=dupl \
-		--enable=gotype \
 		--enable=varcheck \
 		--enable=interfacer \
 		--enable=goconst \
@@ -26,8 +25,7 @@ lint:
 		--enable=misspell \
 		--enable=gas \
 		--enable=goimports \
-		--enable=gocyclo \
-		./...
+		--enable=gocyclo
 
 fmt:
 	go fmt ./...

--- a/cmd/execute_test.go
+++ b/cmd/execute_test.go
@@ -47,7 +47,7 @@ func TestRootCmd(t *testing.T) {
 			t.Errorf("Failed to execute the main command: %+v", err)
 		}
 	case <-time.After(time.Second):
-		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		syscall.Kill(syscall.Getpid(), syscall.SIGTERM) //nolint:errcheck - it's a test don't need to over check
 	case <-time.After(10 * time.Second):
 		t.Error("Timeout waiting for the execute command to exit after SIGTERM")
 	}

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -107,9 +107,6 @@ func TestController(t *testing.T) {
 	n := new(count.Notifier)
 	cont := &testController{}
 	cont.Init(c, n)
-	if cont == nil {
-		t.Errorf("Failed to initialize a test pod controller")
-	}
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -127,7 +124,10 @@ func TestController(t *testing.T) {
 
 	// test deletion
 	store := cont.Informer.GetStore()
-	store.Delete(obj2)
+	err := store.Delete(obj2)
+	if err != nil {
+		t.Fatalf("Unexcepted error %v", err)
+	}
 	time.Sleep(config.FakeResyncInterval + config.FakeResyncInterval/2)
 
 	if n.Count() < 5 {
@@ -140,7 +140,10 @@ func TestController(t *testing.T) {
 	// test retries on notifiers failure
 	fnotif := new(failingNotifier)
 	cont.Notifiers = fnotif
-	store.Add(obj4)
+	err = store.Add(obj4)
+	if err != nil {
+		t.Fatalf("Unexcepted error %v", err)
+	}
 
 	time.Sleep(config.FakeResyncInterval + config.FakeResyncInterval/2)
 	if fnotif.countChange() < maxProcessRetry {

--- a/pkg/controllers/deployment/deployment_test.go
+++ b/pkg/controllers/deployment/deployment_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"k8s.io/api/apps/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/bpineau/kube-deployments-notifier/config"
@@ -25,9 +25,6 @@ func TestDeployment(t *testing.T) {
 	notif := new(count.Notifier)
 	cont := new(Controller)
 	cont.Init(config.FakeConfig(obj1), notif)
-	if cont == nil {
-		t.Errorf("Failed to create a deployment controller")
-	}
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -48,23 +48,24 @@ func TestLog(t *testing.T) {
 	}
 
 	logger = New("info", "127.0.0.1:514", "syslog")
-	if fmt.Sprintf("%T", logger) != "*logrus.Logger" {
+	logrusLoggerPattern := "*logrus.Logger"
+	if fmt.Sprintf("%T", logger) != logrusLoggerPattern {
 		t.Error("Failed to instantiate a syslog logger")
 	}
 
 	logger = New("info", "", "stdout")
-	if fmt.Sprintf("%T", logger) != "*logrus.Logger" {
+	if fmt.Sprintf("%T", logger) != logrusLoggerPattern {
 		t.Error("Failed to instantiate a stdout logger")
 	}
 
 	logger = New("info", "", "stderr")
-	if fmt.Sprintf("%T", logger) != "*logrus.Logger" {
+	if fmt.Sprintf("%T", logger) != logrusLoggerPattern {
 		t.Error("Failed to instantiate a stderr logger")
 	}
 
 	for _, level := range levels {
 		lg := New(level, "", "test")
-		if fmt.Sprintf("%T", lg) != "*logrus.Logger" {
+		if fmt.Sprintf("%T", lg) != logrusLoggerPattern {
 			t.Errorf("Failed to instantiate at %s level", level)
 		}
 	}

--- a/pkg/run/run_test.go
+++ b/pkg/run/run_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"k8s.io/api/apps/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/bpineau/kube-deployments-notifier/config"
@@ -61,6 +61,6 @@ func runFromConf(t *testing.T, conf *config.KdnConfig) {
 		t.Error("Timeout waiting for a event to pop up as a notification")
 	}
 
-	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
-	time.Sleep(300 * time.Millisecond) // controllers wait for 200ms before stopping
+	syscall.Kill(syscall.Getpid(), syscall.SIGTERM) //nolint:errcheck - it's a test don't need to over check
+	time.Sleep(300 * time.Millisecond)              // controllers wait for 200ms before stopping
 }


### PR DESCRIPTION
The maintainer of gometalinter [has deprecated](https://github.com/alecthomas/gometalinter/issues/590) its tool and advise now to
use golangci-lint instead. We can't use the latest version, because it's
not compatible with the current version of Go.

Use the shell script installer instead of `go get` as the authors of the
tool say in the [README](https://github.com/golangci/golangci-lint#binary). It's faster and more reliable to download
directly the binary than build it in.