### PR TITLE
Migrate deployment resource to the latest version

### DIFF
--- a/pkg/controllers/deployment/deployment.go
+++ b/pkg/controllers/deployment/deployment.go
@@ -5,7 +5,7 @@ import (
 	"github.com/bpineau/kube-deployments-notifier/pkg/controllers"
 	"github.com/bpineau/kube-deployments-notifier/pkg/notifiers"
 
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	apps_v1 "k8s.io/api/apps/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -27,14 +27,14 @@ func (c *Controller) Init(conf *config.KdnConfig, n notifiers.Notifier) controll
 	}
 
 	client := c.Conf.ClientSet
-	c.ObjType = &appsv1beta1.Deployment{}
+	c.ObjType = &apps_v1.Deployment{}
 	selector := meta_v1.ListOptions{LabelSelector: conf.Filter}
 	c.ListWatch = &cache.ListWatch{
 		ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-			return client.AppsV1beta1().Deployments(meta_v1.NamespaceAll).List(selector)
+			return client.AppsV1().Deployments(meta_v1.NamespaceAll).List(selector)
 		},
 		WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-			return client.AppsV1beta1().Deployments(meta_v1.NamespaceAll).Watch(selector)
+			return client.AppsV1().Deployments(meta_v1.NamespaceAll).Watch(selector)
 		},
 	}
 

--- a/pkg/controllers/deployment/deployment_test.go
+++ b/pkg/controllers/deployment/deployment_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/apps/v1beta1"
+	apps_v1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	obj1 = &v1beta1.Deployment{ObjectMeta: meta_v1.ObjectMeta{
+	obj1 = &apps_v1.Deployment{ObjectMeta: meta_v1.ObjectMeta{
 		Name:      "test1",
 		Labels:    config.Labels,
 		Namespace: v1.NamespaceDefault},

--- a/pkg/run/run_test.go
+++ b/pkg/run/run_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/apps/v1beta1"
+	apps_v1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	obj1 = &v1beta1.Deployment{ObjectMeta: meta_v1.ObjectMeta{
+	obj1 = &apps_v1.Deployment{ObjectMeta: meta_v1.ObjectMeta{
 		Name:      "test",
 		Labels:    config.Labels,
 		Namespace: v1.NamespaceDefault},


### PR DESCRIPTION
Since version [1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.9.md#apps) the group version of the deployment moved from
appsv1beta to appsv1 and since version [1.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals) the deprecated group is no
longer served. So to support the now version of Kubernetes cluster
kube-deployment-notifier needs this version of deployment.